### PR TITLE
feat: issue #40 expand CMake analysis beyond find_package and ament_package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,26 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
-name = "cmake-parser"
-version = "0.1.0-beta.1"
-dependencies = [
- "cmake-parser-derive",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "cmake-parser-derive"
-version = "0.1.0-beta.1"
-dependencies = [
- "inflections",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,11 +262,11 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
- "cmake-parser",
  "dirs-next",
  "glob",
  "include_dir",
  "regex",
+ "ros-cmake-parser",
  "roxmltree",
  "serde",
  "serde_json",
@@ -438,6 +418,30 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "ros-cmake-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd17065034a653a3c1903dac7ed3b142040c56f46bca7b77dda0052a81b4cc02"
+dependencies = [
+ "nom",
+ "ros-cmake-parser-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "ros-cmake-parser-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34b847b3562837b8a625bbc5b43a505307770b03a96698ff0d51ba953a06323"
+dependencies = [
+ "inflections",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "roxmltree"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,6 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "cmake-parser"
 version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa02b17e863692c3125aeb13eb6ddd3ab2e06e149ac404dc4d045aa3eea1d59"
 dependencies = [
  "cmake-parser-derive",
  "nom",
@@ -133,8 +131,6 @@ dependencies = [
 [[package]]
 name = "cmake-parser-derive"
 version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a051b4c9c0fa30b2fbc858ce06eeccf849361974edb6a4c16c7f78b4c6eb810"
 dependencies = [
  "inflections",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -118,6 +118,30 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "cmake-parser"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa02b17e863692c3125aeb13eb6ddd3ab2e06e149ac404dc4d045aa3eea1d59"
+dependencies = [
+ "cmake-parser-derive",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "cmake-parser-derive"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a051b4c9c0fa30b2fbc858ce06eeccf849361974edb6a4c16c7f78b4c6eb810"
+dependencies = [
+ "inflections",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "colorchoice"
@@ -239,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +286,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
+ "cmake-parser",
  "dirs-next",
  "glob",
  "include_dir",
@@ -297,6 +328,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +354,30 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -430,7 +501,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -460,6 +531,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -502,7 +583,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -555,6 +636,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,12 @@ serde_json = "1.0.148"
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 regex = "1.10"
-cmake-parser = "0.1.0-beta.1"
+ros-cmake-parser = "0.1.1"
 toml = "0.9.8"
 glob = "0.3"
 dirs-next = "2.0"
 include_dir = "0.7"
 tempfile = "3.5"
 
-[patch.crates-io]
-cmake-parser = { path = "../ros-cmake-parser/lib" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,7 @@ dirs-next = "2.0"
 include_dir = "0.7"
 tempfile = "3.5"
 
+[patch.crates-io]
+cmake-parser = { path = "../ros-cmake-parser/lib" }
+
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.148"
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 regex = "1.10"
+cmake-parser = "0.1.0-beta.1"
 toml = "0.9.8"
 glob = "0.3"
 dirs-next = "2.0"

--- a/docs/issue-40-cmake-parser-plan.md
+++ b/docs/issue-40-cmake-parser-plan.md
@@ -1,0 +1,77 @@
+# Issue #40 CMake parser adapter plan
+
+## Goal
+
+Replace the current ad-hoc `src/parsers/cmake.rs` logic with an adapter over an external Rust CMake parser crate, while preserving valuable behavior-focused tests.
+
+## Why
+
+The PR history for issue #40 shows repeated review-driven fixes around:
+
+- case-insensitive command handling
+- comment stripping
+- independent `find_package(...)` parsing
+- standalone `REQUIRED` detection
+- wrapper macro false positives
+- keyword filtering in `ament_target_dependencies(...)`
+- keyword filtering in `target_link_libraries(...)`
+- variable-based target names
+
+Those are useful behavioral requirements, but continuing to implement them through local regex/state logic is likely the wrong maintenance path.
+
+## Proposed direction
+
+- Use `cmake-parser` as the source parser for CMake syntax.
+- Keep this repository responsible only for extracting analysis-relevant facts.
+- Avoid re-expanding `CMakeInfo` into a clone of the parser crate's model.
+- Prefer a thin adapter in `src/parsers/cmake.rs`.
+
+## Data we likely still need in Kiboku
+
+- `find_package(...)`
+  - package name
+  - optional version
+  - whether `REQUIRED` is present as a standalone token
+- whether `catkin_package()` exists
+- whether `ament_package()` exists
+- target declarations
+  - executable names
+  - library names
+- target dependency/link relations
+  - `ament_target_dependencies(target ...)`
+  - `target_link_libraries(target ...)`
+
+## Design shape
+
+Possible split:
+
+1. Parse full CMake doc with external crate.
+2. Walk parser commands.
+3. Extract only Kiboku-facing facts.
+4. Store them in a minimal analysis struct.
+
+If needed, `CMakeInfo` can remain a compact DTO for downstream code, but should not try to mirror the full parser AST.
+
+## Test policy
+
+Treat existing issue #40 tests as behavior/spec tests, not implementation tests.
+
+Keep (or adapt) tests for:
+
+- multiple `find_package(...)` calls
+- uppercase / mixed-case command handling
+- comment handling
+- `REQUIRED` token semantics
+- wrapper macro exclusion
+- variable target names
+- keyword filtering in dependency/link extraction
+
+Potentially relax tests that overfit the old homemade parser structure rather than Kiboku's real analysis needs.
+
+## Immediate next steps
+
+1. Add the parser crate dependency.
+2. Build a tiny spike that parses a synthetic CMakeLists snippet.
+3. Inspect crate model / API shape in local build output.
+4. Implement adapter extraction for the smallest useful subset.
+5. Reconcile existing tests with the new adapter.

--- a/src/models/cmake.rs
+++ b/src/models/cmake.rs
@@ -8,8 +8,24 @@ pub struct FindPackage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TargetDependencies {
+    pub target: String,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TargetLinks {
+    pub target: String,
+    pub libraries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CMakeInfo {
     pub find_packages: Vec<FindPackage>,
     pub has_catkin_package: bool,
     pub has_ament_package: bool,
+    pub executables: Vec<String>,
+    pub libraries: Vec<String>,
+    pub ament_target_dependencies: Vec<TargetDependencies>,
+    pub target_link_libraries: Vec<TargetLinks>,
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -8,7 +8,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let mut info = CMakeInfo::default();
 
     let re_find =
-        Regex::new(r"find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?(?:.*REQUIRED)?\)")
+        Regex::new(r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?(?:.*REQUIRED)?\)")
             .unwrap();
     for cap in re_find.captures_iter(&text) {
         let name = cap
@@ -27,21 +27,21 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         });
     }
 
-    let re_exe = Regex::new(r"add_executable\s*\(\s*([^\s\)]+)").unwrap();
+    let re_exe = Regex::new(r"(?i)add_executable\s*\(\s*([^\s\)]+)").unwrap();
     for cap in re_exe.captures_iter(&text) {
         if let Some(name) = cap.get(1) {
             info.executables.push(name.as_str().to_string());
         }
     }
 
-    let re_lib = Regex::new(r"add_library\s*\(\s*([^\s\)]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
+    let re_lib = Regex::new(r"(?i)add_library\s*\(\s*([^\s\)]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
     for cap in re_lib.captures_iter(&text) {
         if let Some(name) = cap.get(1) {
             info.libraries.push(name.as_str().to_string());
         }
     }
 
-    let re_ament_deps = Regex::new(r"ament_target_dependencies\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
+    let re_ament_deps = Regex::new(r"(?i)ament_target_dependencies\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
     for cap in re_ament_deps.captures_iter(&text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let dependencies = cap
@@ -51,7 +51,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         info.ament_target_dependencies.push(TargetDependencies { target, dependencies });
     }
 
-    let re_target_links = Regex::new(r"target_link_libraries\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
+    let re_target_links = Regex::new(r"(?i)target_link_libraries\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
     for cap in re_target_links.captures_iter(&text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let libraries = cap
@@ -71,8 +71,17 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     Ok(info)
 }
 
+fn strip_cmake_line_comments(s: &str) -> String {
+    s.lines()
+        .map(|line| line.split('#').next().unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
-    s.split_whitespace()
+    let cleaned = strip_cmake_line_comments(s);
+    cleaned
+        .split_whitespace()
         .filter(|item| !item.is_empty())
         .filter(|item| !matches!(*item, "SYSTEM" | "PUBLIC" | "INTERFACE"))
         .map(|item| item.trim().to_string())
@@ -80,7 +89,9 @@ fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
 }
 
 fn split_link_libraries_args(s: &str) -> Vec<String> {
-    s.split_whitespace()
+    let cleaned = strip_cmake_line_comments(s);
+    cleaned
+        .split_whitespace()
         .filter(|item| !item.is_empty())
         .filter(|item| {
             !matches!(

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -1,25 +1,24 @@
 use crate::models::cmake::{CMakeInfo, FindPackage, TargetDependencies, TargetLinks};
 use anyhow::Result;
-use cmake_parser::{parse_cmakelists, Command, Doc, Token};
-use regex::Regex;
+use cmake_parser::{parse_cmakelists, Command, Doc, RosCommand, Token};
 use std::fs;
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
-    let aux_text = strip_cmake_bracket_comments(&text);
     let mut info = CMakeInfo::default();
 
-    parse_standard_commands(&text, &mut info)?;
-    normalize_find_package_required_flags(&aux_text, &mut info)?;
-    parse_ros_commands(&aux_text, &mut info)?;
+    let parse_text = if text.ends_with("\n") { text.clone() } else { format!("{text}\n") };
+    let tokens = parse_cmakelists(parse_text.as_bytes())?;
+    let doc = Doc::from(tokens);
+
+    parse_standard_commands(&doc, &mut info)?;
+    normalize_find_package_required_flags(&doc, &mut info);
+    parse_ros_and_raw_commands(&doc, &mut info);
 
     Ok(info)
 }
 
-fn parse_standard_commands(text: &str, info: &mut CMakeInfo) -> Result<()> {
-    let tokens = parse_cmakelists(text.as_bytes())?;
-    let doc = Doc::from(tokens);
-
+fn parse_standard_commands(doc: &Doc<'_>, info: &mut CMakeInfo) -> Result<()> {
     for cmd in doc.to_commands_iter() {
         let Ok(cmd) = cmd else {
             continue;
@@ -59,80 +58,52 @@ fn parse_standard_commands(text: &str, info: &mut CMakeInfo) -> Result<()> {
     Ok(())
 }
 
-fn normalize_find_package_required_flags(text: &str, info: &mut CMakeInfo) -> Result<()> {
-    let re_find = Regex::new(r"(?is)(?m)(^|\n)\s*find_package\s*\((.*?)\)")?;
-    let mut required_by_index = Vec::new();
+fn normalize_find_package_required_flags(doc: &Doc<'_>, info: &mut CMakeInfo) {
+    let required_by_index = doc
+        .raw_commands()
+        .filter(|raw| eq_ignore_ascii_case(raw.identifier.as_ref(), b"find_package"))
+        .filter(|raw| !raw.tokens.is_empty())
+        .map(|raw| {
+            raw.tokens
+                .iter()
+                .skip(1)
+                .any(|t| eq_ignore_ascii_case(t.as_ref(), b"REQUIRED"))
+        });
 
-    for cap in re_find.captures_iter(text) {
-        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
-            continue;
-        };
-        let tokens = tokenize_unquoted_args(args);
-        if tokens.is_empty() {
-            continue;
-        }
-        required_by_index.push(tokens.iter().skip(1).any(|t| t.eq_ignore_ascii_case("REQUIRED")));
-    }
-
-    for (pkg, required) in info.find_packages.iter_mut().zip(required_by_index.into_iter()) {
+    for (pkg, required) in info.find_packages.iter_mut().zip(required_by_index) {
         pkg.required = required;
     }
-
-    Ok(())
 }
 
-fn parse_ros_commands(text: &str, info: &mut CMakeInfo) -> Result<()> {
-    let re_pkg = Regex::new(r"(?is)(?m)(^|\n)\s*(catkin_package|ament_package)\s*\((.*?)\)")?;
-    for cap in re_pkg.captures_iter(text) {
-        let Some(name) = cap.get(2).map(|m| m.as_str().to_ascii_lowercase()) else {
-            continue;
-        };
-        match name.as_str() {
-            "catkin_package" => info.has_catkin_package = true,
-            "ament_package" => info.has_ament_package = true,
-            _ => {}
+fn parse_ros_and_raw_commands(doc: &Doc<'_>, info: &mut CMakeInfo) {
+    for cmd in doc.ros_commands() {
+        match cmd {
+            RosCommand::AmentPackage => info.has_ament_package = true,
+            RosCommand::CatkinPackage => info.has_catkin_package = true,
+            RosCommand::AmentTargetDependencies(dep) => {
+                info.ament_target_dependencies.push(TargetDependencies {
+                    target: dep.target.to_string(),
+                    dependencies: dep.dependencies.iter().map(ToString::to_string).collect(),
+                });
+            }
         }
     }
 
-    let re_ament = Regex::new(r"(?is)(?m)(^|\n)\s*ament_target_dependencies\s*\((.*?)\)")?;
-    for cap in re_ament.captures_iter(text) {
-        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
-            continue;
-        };
-        let tokens = tokenize_unquoted_args(args);
-        if let Some((target, rest)) = tokens.split_first() {
-            let dependencies = rest
-                .iter()
-                .filter(|item| !is_ament_dependency_keyword(item))
-                .cloned()
-                .collect::<Vec<_>>();
-            info.ament_target_dependencies.push(TargetDependencies {
-                target: target.clone(),
-                dependencies,
-            });
+    for raw in doc.raw_commands() {
+        if eq_ignore_ascii_case(raw.identifier.as_ref(), b"target_link_libraries") {
+            if let Some((target, rest)) = raw.tokens.split_first() {
+                let libraries = rest
+                    .iter()
+                    .filter(|token| !is_target_link_keyword(token.as_ref()))
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>();
+                info.target_link_libraries.push(TargetLinks {
+                    target: target.to_string(),
+                    libraries,
+                });
+            }
         }
     }
-
-    let re_link = Regex::new(r"(?is)(?m)(^|\n)\s*target_link_libraries\s*\((.*?)\)")?;
-    for cap in re_link.captures_iter(text) {
-        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
-            continue;
-        };
-        let tokens = tokenize_unquoted_args(args);
-        if let Some((target, rest)) = tokens.split_first() {
-            let libraries = rest
-                .iter()
-                .filter(|item| !is_target_link_keyword(item))
-                .cloned()
-                .collect::<Vec<_>>();
-            info.target_link_libraries.push(TargetLinks {
-                target: target.clone(),
-                libraries,
-            });
-        }
-    }
-
-    Ok(())
 }
 
 fn required_from_basic_components(
@@ -153,79 +124,9 @@ fn token_to_string(token: &Token<'_>) -> String {
     token.to_string()
 }
 
-fn tokenize_unquoted_args(s: &str) -> Vec<String> {
-    let mut stripped = String::new();
-    for line in s.lines() {
-        let before_comment = line.split('#').next().unwrap_or_default();
-        stripped.push_str(before_comment);
-        stripped.push('\n');
-    }
-    stripped
-        .split_whitespace()
-        .map(|x| x.to_string())
-        .collect()
-}
-
-fn strip_cmake_bracket_comments(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out = String::with_capacity(s.len());
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        if bytes[i] == b'#' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
-            let mut eqs = 0usize;
-            let mut j = i + 2;
-            while j < bytes.len() && bytes[j] == b'=' {
-                eqs += 1;
-                j += 1;
-            }
-            if j < bytes.len() && bytes[j] == b'[' {
-                let start = j + 1;
-                let mut k = start;
-                let mut found = false;
-                while k < bytes.len() {
-                    if bytes[k] == b']' {
-                        let mut m = k + 1;
-                        let mut matched_eqs = 0usize;
-                        while matched_eqs < eqs && m < bytes.len() && bytes[m] == b'=' {
-                            matched_eqs += 1;
-                            m += 1;
-                        }
-                        if matched_eqs == eqs && m < bytes.len() && bytes[m] == b']' {
-                            for &b in &bytes[i..=m] {
-                                if b == b'\n' {
-                                    out.push('\n');
-                                } else {
-                                    out.push(' ');
-                                }
-                            }
-                            i = m + 1;
-                            found = true;
-                            break;
-                        }
-                    }
-                    k += 1;
-                }
-                if found {
-                    continue;
-                }
-            }
-        }
-
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-
-    out
-}
-
-fn is_ament_dependency_keyword(s: &str) -> bool {
-    matches!(s.to_ascii_uppercase().as_str(), "SYSTEM" | "PUBLIC" | "INTERFACE")
-}
-
-fn is_target_link_keyword(s: &str) -> bool {
+fn is_target_link_keyword(token: &[u8]) -> bool {
     matches!(
-        s.to_ascii_uppercase().as_str(),
+        ascii_upper(token).as_str(),
         "PUBLIC"
             | "PRIVATE"
             | "INTERFACE"
@@ -236,4 +137,12 @@ fn is_target_link_keyword(s: &str) -> bool {
             | "LINK_PRIVATE"
             | "LINK_INTERFACE_LIBRARIES"
     )
+}
+
+fn eq_ignore_ascii_case(left: &[u8], right: &[u8]) -> bool {
+    left.eq_ignore_ascii_case(right)
+}
+
+fn ascii_upper(token: &[u8]) -> String {
+    String::from_utf8_lossy(token).to_ascii_uppercase()
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -1,13 +1,17 @@
 use crate::models::cmake::{CMakeInfo, FindPackage, TargetDependencies, TargetLinks};
 use anyhow::Result;
-use cmake_parser::{parse_cmakelists, Command, Doc, RosCommand, Token};
+use ros_cmake_parser::{parse_cmakelists, Command, Doc, RosCommand, Token};
 use std::fs;
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
     let mut info = CMakeInfo::default();
 
-    let parse_text = if text.ends_with("\n") { text.clone() } else { format!("{text}\n") };
+    let parse_text = if text.ends_with("\n") {
+        text.clone()
+    } else {
+        format!("{text}\n")
+    };
     let tokens = parse_cmakelists(parse_text.as_bytes())?;
     let doc = Doc::from(tokens);
 
@@ -27,12 +31,12 @@ fn parse_standard_commands(doc: &Doc<'_>, info: &mut CMakeInfo) -> Result<()> {
         match cmd {
             Command::FindPackage(pkg) => {
                 let (name, version, required) = match pkg.as_ref() {
-                    cmake_parser::command::scripting::FindPackage::Basic(basic) => (
+                    ros_cmake_parser::command::scripting::FindPackage::Basic(basic) => (
                         token_to_string(&basic.package_name),
                         basic.version.as_ref().map(token_to_string),
                         required_from_basic_components(basic.components.as_ref()),
                     ),
-                    cmake_parser::command::scripting::FindPackage::Full(full) => (
+                    ros_cmake_parser::command::scripting::FindPackage::Full(full) => (
                         token_to_string(&full.package_name),
                         full.version.as_ref().map(token_to_string),
                         required_from_full_components(full.components.as_ref()),
@@ -107,16 +111,16 @@ fn parse_ros_and_raw_commands(doc: &Doc<'_>, info: &mut CMakeInfo) {
 }
 
 fn required_from_basic_components(
-    components: Option<&cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
+    components: Option<&ros_cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
 ) -> bool {
-    use cmake_parser::command::scripting::find_package::PackageComponents;
+    use ros_cmake_parser::command::scripting::find_package::PackageComponents;
     matches!(components, Some(PackageComponents::Required(_)))
 }
 
 fn required_from_full_components(
-    components: Option<&cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
+    components: Option<&ros_cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
 ) -> bool {
-    use cmake_parser::command::scripting::find_package::PackageComponents;
+    use ros_cmake_parser::command::scripting::find_package::PackageComponents;
     matches!(components, Some(PackageComponents::Required(_)))
 }
 

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -27,21 +27,21 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         });
     }
 
-    let re_exe = Regex::new(r"add_executable\s*\(\s*([A-Za-z0-9_:+-]+)").unwrap();
+    let re_exe = Regex::new(r"add_executable\s*\(\s*([^\s\)]+)").unwrap();
     for cap in re_exe.captures_iter(&text) {
         if let Some(name) = cap.get(1) {
             info.executables.push(name.as_str().to_string());
         }
     }
 
-    let re_lib = Regex::new(r"add_library\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
+    let re_lib = Regex::new(r"add_library\s*\(\s*([^\s\)]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
     for cap in re_lib.captures_iter(&text) {
         if let Some(name) = cap.get(1) {
             info.libraries.push(name.as_str().to_string());
         }
     }
 
-    let re_ament_deps = Regex::new(r"ament_target_dependencies\s*\(\s*([A-Za-z0-9_:+-]+)\s+([^\)]*)\)").unwrap();
+    let re_ament_deps = Regex::new(r"ament_target_dependencies\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
     for cap in re_ament_deps.captures_iter(&text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let dependencies = cap
@@ -51,12 +51,12 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         info.ament_target_dependencies.push(TargetDependencies { target, dependencies });
     }
 
-    let re_target_links = Regex::new(r"target_link_libraries\s*\(\s*([A-Za-z0-9_:+-]+)\s+([^\)]*)\)").unwrap();
+    let re_target_links = Regex::new(r"target_link_libraries\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
     for cap in re_target_links.captures_iter(&text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let libraries = cap
             .get(2)
-            .map(|m| split_cmake_args(m.as_str()))
+            .map(|m| split_link_libraries_args(m.as_str()))
             .unwrap_or_default();
         info.target_link_libraries.push(TargetLinks { target, libraries });
     }
@@ -74,6 +74,19 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
 fn split_cmake_args(s: &str) -> Vec<String> {
     s.split_whitespace()
         .filter(|item| !item.is_empty())
+        .map(|item| item.trim().to_string())
+        .collect()
+}
+
+fn split_link_libraries_args(s: &str) -> Vec<String> {
+    s.split_whitespace()
+        .filter(|item| !item.is_empty())
+        .filter(|item| {
+            !matches!(
+                *item,
+                "PUBLIC" | "PRIVATE" | "INTERFACE" | "debug" | "optimized" | "general"
+            )
+        })
         .map(|item| item.trim().to_string())
         .collect()
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -7,8 +7,8 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
     let mut info = CMakeInfo::default();
 
-    let parse_text = if text.ends_with("\n") {
-        text.clone()
+    let parse_text = if text.ends_with('\n') {
+        text
     } else {
         format!("{text}\n")
     };

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -1,4 +1,4 @@
-use crate::models::cmake::{CMakeInfo, FindPackage};
+use crate::models::cmake::{CMakeInfo, FindPackage, TargetDependencies, TargetLinks};
 use anyhow::Result;
 use regex::Regex;
 use std::fs;
@@ -27,6 +27,40 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         });
     }
 
+    let re_exe = Regex::new(r"add_executable\s*\(\s*([A-Za-z0-9_:+-]+)").unwrap();
+    for cap in re_exe.captures_iter(&text) {
+        if let Some(name) = cap.get(1) {
+            info.executables.push(name.as_str().to_string());
+        }
+    }
+
+    let re_lib = Regex::new(r"add_library\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
+    for cap in re_lib.captures_iter(&text) {
+        if let Some(name) = cap.get(1) {
+            info.libraries.push(name.as_str().to_string());
+        }
+    }
+
+    let re_ament_deps = Regex::new(r"ament_target_dependencies\s*\(\s*([A-Za-z0-9_:+-]+)\s+([^\)]*)\)").unwrap();
+    for cap in re_ament_deps.captures_iter(&text) {
+        let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+        let dependencies = cap
+            .get(2)
+            .map(|m| split_cmake_args(m.as_str()))
+            .unwrap_or_default();
+        info.ament_target_dependencies.push(TargetDependencies { target, dependencies });
+    }
+
+    let re_target_links = Regex::new(r"target_link_libraries\s*\(\s*([A-Za-z0-9_:+-]+)\s+([^\)]*)\)").unwrap();
+    for cap in re_target_links.captures_iter(&text) {
+        let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+        let libraries = cap
+            .get(2)
+            .map(|m| split_cmake_args(m.as_str()))
+            .unwrap_or_default();
+        info.target_link_libraries.push(TargetLinks { target, libraries });
+    }
+
     if text.contains("catkin_package") {
         info.has_catkin_package = true;
     }
@@ -35,4 +69,11 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     }
 
     Ok(info)
+}
+
+fn split_cmake_args(s: &str) -> Vec<String> {
+    s.split_whitespace()
+        .filter(|item| !item.is_empty())
+        .map(|item| item.trim().to_string())
+        .collect()
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -8,9 +8,10 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let uncommented_text = strip_cmake_line_comments(&text);
     let mut info = CMakeInfo::default();
 
-    let re_find =
-        Regex::new(r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?(?:.*required)?\)")
-            .unwrap();
+    let re_find = Regex::new(
+        r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?([^\)]*)\)"
+    )
+    .unwrap();
     for cap in re_find.captures_iter(&uncommented_text) {
         let name = cap
             .get(1)
@@ -18,7 +19,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
             .unwrap_or_default();
         let version = cap.get(2).map(|m| m.as_str().to_string());
         let required = cap
-            .get(0)
+            .get(3)
             .map(|m| m.as_str().to_ascii_lowercase().contains("required"))
             .unwrap_or(false);
         info.find_packages.push(FindPackage {

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -20,7 +20,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         let version = cap.get(2).map(|m| m.as_str().to_string());
         let required = cap
             .get(3)
-            .map(|m| m.as_str().to_ascii_lowercase().contains("required"))
+            .map(|m| has_required_token(m.as_str()))
             .unwrap_or(false);
         info.find_packages.push(FindPackage {
             name,
@@ -80,6 +80,11 @@ fn strip_cmake_line_comments(s: &str) -> String {
         .map(|line| line.split('#').next().unwrap_or_default())
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn has_required_token(s: &str) -> bool {
+    s.split_whitespace()
+        .any(|item| item.eq_ignore_ascii_case("REQUIRED"))
 }
 
 fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -46,7 +46,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let dependencies = cap
             .get(2)
-            .map(|m| split_cmake_args(m.as_str()))
+            .map(|m| split_ament_target_dependencies_args(m.as_str()))
             .unwrap_or_default();
         info.ament_target_dependencies.push(TargetDependencies { target, dependencies });
     }
@@ -78,13 +78,29 @@ fn split_cmake_args(s: &str) -> Vec<String> {
         .collect()
 }
 
+fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
+    s.split_whitespace()
+        .filter(|item| !item.is_empty())
+        .filter(|item| !matches!(*item, "SYSTEM" | "PUBLIC" | "INTERFACE"))
+        .map(|item| item.trim().to_string())
+        .collect()
+}
+
 fn split_link_libraries_args(s: &str) -> Vec<String> {
     s.split_whitespace()
         .filter(|item| !item.is_empty())
         .filter(|item| {
             !matches!(
                 *item,
-                "PUBLIC" | "PRIVATE" | "INTERFACE" | "debug" | "optimized" | "general"
+                "PUBLIC"
+                    | "PRIVATE"
+                    | "INTERFACE"
+                    | "debug"
+                    | "optimized"
+                    | "general"
+                    | "LINK_PUBLIC"
+                    | "LINK_PRIVATE"
+                    | "LINK_INTERFACE_LIBRARIES"
             )
         })
         .map(|item| item.trim().to_string())

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -71,13 +71,6 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     Ok(info)
 }
 
-fn split_cmake_args(s: &str) -> Vec<String> {
-    s.split_whitespace()
-        .filter(|item| !item.is_empty())
-        .map(|item| item.trim().to_string())
-        .collect()
-}
-
 fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
     s.split_whitespace()
         .filter(|item| !item.is_empty())

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -5,12 +5,13 @@ use std::fs;
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
+    let uncommented_text = strip_cmake_line_comments(&text);
     let mut info = CMakeInfo::default();
 
     let re_find =
-        Regex::new(r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?(?:.*REQUIRED)?\)")
+        Regex::new(r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?(?:.*required)?\)")
             .unwrap();
-    for cap in re_find.captures_iter(&text) {
+    for cap in re_find.captures_iter(&uncommented_text) {
         let name = cap
             .get(1)
             .map(|m| m.as_str().to_string())
@@ -18,7 +19,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         let version = cap.get(2).map(|m| m.as_str().to_string());
         let required = cap
             .get(0)
-            .map(|m| m.as_str().contains("REQUIRED"))
+            .map(|m| m.as_str().to_ascii_lowercase().contains("required"))
             .unwrap_or(false);
         info.find_packages.push(FindPackage {
             name,
@@ -28,21 +29,21 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     }
 
     let re_exe = Regex::new(r"(?i)add_executable\s*\(\s*([^\s\)]+)").unwrap();
-    for cap in re_exe.captures_iter(&text) {
+    for cap in re_exe.captures_iter(&uncommented_text) {
         if let Some(name) = cap.get(1) {
             info.executables.push(name.as_str().to_string());
         }
     }
 
     let re_lib = Regex::new(r"(?i)add_library\s*\(\s*([^\s\)]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
-    for cap in re_lib.captures_iter(&text) {
+    for cap in re_lib.captures_iter(&uncommented_text) {
         if let Some(name) = cap.get(1) {
             info.libraries.push(name.as_str().to_string());
         }
     }
 
     let re_ament_deps = Regex::new(r"(?i)ament_target_dependencies\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
-    for cap in re_ament_deps.captures_iter(&text) {
+    for cap in re_ament_deps.captures_iter(&uncommented_text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let dependencies = cap
             .get(2)
@@ -52,7 +53,7 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     }
 
     let re_target_links = Regex::new(r"(?i)target_link_libraries\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
-    for cap in re_target_links.captures_iter(&text) {
+    for cap in re_target_links.captures_iter(&uncommented_text) {
         let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
         let libraries = cap
             .get(2)
@@ -61,10 +62,10 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         info.target_link_libraries.push(TargetLinks { target, libraries });
     }
 
-    if text.contains("catkin_package") {
+    if uncommented_text.to_ascii_lowercase().contains("catkin_package") {
         info.has_catkin_package = true;
     }
-    if text.contains("ament_package") {
+    if uncommented_text.to_ascii_lowercase().contains("ament_package") {
         info.has_ament_package = true;
     }
 
@@ -83,7 +84,10 @@ fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
     cleaned
         .split_whitespace()
         .filter(|item| !item.is_empty())
-        .filter(|item| !matches!(*item, "SYSTEM" | "PUBLIC" | "INTERFACE"))
+        .filter(|item| {
+            let upper = item.to_ascii_uppercase();
+            !matches!(upper.as_str(), "SYSTEM" | "PUBLIC" | "INTERFACE")
+        })
         .map(|item| item.trim().to_string())
         .collect()
 }
@@ -94,14 +98,15 @@ fn split_link_libraries_args(s: &str) -> Vec<String> {
         .split_whitespace()
         .filter(|item| !item.is_empty())
         .filter(|item| {
+            let upper = item.to_ascii_uppercase();
             !matches!(
-                *item,
+                upper.as_str(),
                 "PUBLIC"
                     | "PRIVATE"
                     | "INTERFACE"
-                    | "debug"
-                    | "optimized"
-                    | "general"
+                    | "DEBUG"
+                    | "OPTIMIZED"
+                    | "GENERAL"
                     | "LINK_PUBLIC"
                     | "LINK_PRIVATE"
                     | "LINK_INTERFACE_LIBRARIES"

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -1,125 +1,261 @@
 use crate::models::cmake::{CMakeInfo, FindPackage, TargetDependencies, TargetLinks};
 use anyhow::Result;
-use regex::Regex;
 use std::fs;
+
+#[derive(Debug, Clone)]
+struct CMakeCommand {
+    name: String,
+    args_raw: String,
+}
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
-    let uncommented_text = strip_cmake_line_comments(&text);
+    let commands = extract_cmake_commands(&text);
     let mut info = CMakeInfo::default();
 
-    let re_find = Regex::new(
-        r"(?i)find_package\s*\(\s*([A-Za-z0-9_:+-]+)(?:\s+([0-9\.]+))?([^\)]*)\)"
-    )
-    .unwrap();
-    for cap in re_find.captures_iter(&uncommented_text) {
-        let name = cap
-            .get(1)
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_default();
-        let version = cap.get(2).map(|m| m.as_str().to_string());
-        let required = cap
-            .get(3)
-            .map(|m| has_required_token(m.as_str()))
-            .unwrap_or(false);
-        info.find_packages.push(FindPackage {
-            name,
-            version,
-            required,
-        });
-    }
-
-    let re_exe = Regex::new(r"(?i)add_executable\s*\(\s*([^\s\)]+)").unwrap();
-    for cap in re_exe.captures_iter(&uncommented_text) {
-        if let Some(name) = cap.get(1) {
-            info.executables.push(name.as_str().to_string());
+    for cmd in &commands {
+        match cmd.name.as_str() {
+            "find_package" => {
+                let tokens = tokenize_cmake_args(&cmd.args_raw);
+                if tokens.is_empty() {
+                    continue;
+                }
+                let name = tokens[0].clone();
+                let version = tokens
+                    .get(1)
+                    .filter(|t| t.chars().all(|c| c.is_ascii_digit() || c == '.'))
+                    .cloned();
+                let required = tokens.iter().any(|t| t.eq_ignore_ascii_case("REQUIRED"));
+                info.find_packages.push(FindPackage {
+                    name,
+                    version,
+                    required,
+                });
+            }
+            "add_executable" => {
+                let tokens = tokenize_cmake_args(&cmd.args_raw);
+                if let Some(target) = tokens.first() {
+                    info.executables.push(target.clone());
+                }
+            }
+            "add_library" => {
+                let tokens = tokenize_cmake_args(&cmd.args_raw);
+                if let Some(target) = tokens.first() {
+                    info.libraries.push(target.clone());
+                }
+            }
+            "ament_target_dependencies" => {
+                let tokens = tokenize_cmake_args(&cmd.args_raw);
+                if let Some((target, rest)) = tokens.split_first() {
+                    let dependencies = rest
+                        .iter()
+                        .filter(|item| {
+                            !matches!(
+                                item.to_ascii_uppercase().as_str(),
+                                "SYSTEM" | "PUBLIC" | "INTERFACE"
+                            )
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    info.ament_target_dependencies.push(TargetDependencies {
+                        target: target.clone(),
+                        dependencies,
+                    });
+                }
+            }
+            "target_link_libraries" => {
+                let tokens = tokenize_cmake_args(&cmd.args_raw);
+                if let Some((target, rest)) = tokens.split_first() {
+                    let libraries = rest
+                        .iter()
+                        .filter(|item| {
+                            !matches!(
+                                item.to_ascii_uppercase().as_str(),
+                                "PUBLIC"
+                                    | "PRIVATE"
+                                    | "INTERFACE"
+                                    | "DEBUG"
+                                    | "OPTIMIZED"
+                                    | "GENERAL"
+                                    | "LINK_PUBLIC"
+                                    | "LINK_PRIVATE"
+                                    | "LINK_INTERFACE_LIBRARIES"
+                            )
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    info.target_link_libraries.push(TargetLinks {
+                        target: target.clone(),
+                        libraries,
+                    });
+                }
+            }
+            "catkin_package" => {
+                info.has_catkin_package = true;
+            }
+            "ament_package" => {
+                info.has_ament_package = true;
+            }
+            _ => {}
         }
-    }
-
-    let re_lib = Regex::new(r"(?i)add_library\s*\(\s*([^\s\)]+)(?:\s+(?:STATIC|SHARED|MODULE|OBJECT|INTERFACE))?").unwrap();
-    for cap in re_lib.captures_iter(&uncommented_text) {
-        if let Some(name) = cap.get(1) {
-            info.libraries.push(name.as_str().to_string());
-        }
-    }
-
-    let re_ament_deps = Regex::new(r"(?i)ament_target_dependencies\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
-    for cap in re_ament_deps.captures_iter(&uncommented_text) {
-        let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
-        let dependencies = cap
-            .get(2)
-            .map(|m| split_ament_target_dependencies_args(m.as_str()))
-            .unwrap_or_default();
-        info.ament_target_dependencies.push(TargetDependencies { target, dependencies });
-    }
-
-    let re_target_links = Regex::new(r"(?i)target_link_libraries\s*\(\s*([^\s\)]+)\s+([^\)]*)\)").unwrap();
-    for cap in re_target_links.captures_iter(&uncommented_text) {
-        let target = cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
-        let libraries = cap
-            .get(2)
-            .map(|m| split_link_libraries_args(m.as_str()))
-            .unwrap_or_default();
-        info.target_link_libraries.push(TargetLinks { target, libraries });
-    }
-
-    let re_catkin_package = Regex::new(r"(?i)\bcatkin_package\s*\(").unwrap();
-    if re_catkin_package.is_match(&uncommented_text) {
-        info.has_catkin_package = true;
-    }
-    let re_ament_package = Regex::new(r"(?i)\bament_package\s*\(").unwrap();
-    if re_ament_package.is_match(&uncommented_text) {
-        info.has_ament_package = true;
     }
 
     Ok(info)
 }
 
-fn strip_cmake_line_comments(s: &str) -> String {
-    s.lines()
-        .map(|line| line.split('#').next().unwrap_or_default())
-        .collect::<Vec<_>>()
-        .join(" ")
+fn extract_cmake_commands(s: &str) -> Vec<CMakeCommand> {
+    let mut commands = Vec::new();
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        if chars[i] == '#' {
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
+            let start = i;
+            i += 1;
+            while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                i += 1;
+            }
+            let name: String = chars[start..i].iter().collect();
+
+            let mut j = i;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j >= chars.len() || chars[j] != '(' {
+                i = j;
+                continue;
+            }
+
+            j += 1;
+            let args_start = j;
+            let mut depth = 1i32;
+            let mut in_single = false;
+            let mut in_double = false;
+            let mut escaped = false;
+
+            while j < chars.len() {
+                let c = chars[j];
+                if escaped {
+                    escaped = false;
+                    j += 1;
+                    continue;
+                }
+                if c == '\\' && (in_single || in_double) {
+                    escaped = true;
+                    j += 1;
+                    continue;
+                }
+                if c == '"' && !in_single {
+                    in_double = !in_double;
+                    j += 1;
+                    continue;
+                }
+                if c == '\'' && !in_double {
+                    in_single = !in_single;
+                    j += 1;
+                    continue;
+                }
+                if in_single || in_double {
+                    j += 1;
+                    continue;
+                }
+                if c == '#' {
+                    while j < chars.len() && chars[j] != '\n' {
+                        j += 1;
+                    }
+                    continue;
+                }
+                if c == '(' {
+                    depth += 1;
+                } else if c == ')' {
+                    depth -= 1;
+                    if depth == 0 {
+                        let args_raw: String = chars[args_start..j].iter().collect();
+                        commands.push(CMakeCommand {
+                            name: name.to_ascii_lowercase(),
+                            args_raw,
+                        });
+                        j += 1;
+                        break;
+                    }
+                }
+                j += 1;
+            }
+            i = j;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    commands
 }
 
-fn has_required_token(s: &str) -> bool {
-    s.split_whitespace()
-        .any(|item| item.eq_ignore_ascii_case("REQUIRED"))
-}
+fn tokenize_cmake_args(s: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
 
-fn split_ament_target_dependencies_args(s: &str) -> Vec<String> {
-    let cleaned = strip_cmake_line_comments(s);
-    cleaned
-        .split_whitespace()
-        .filter(|item| !item.is_empty())
-        .filter(|item| {
-            let upper = item.to_ascii_uppercase();
-            !matches!(upper.as_str(), "SYSTEM" | "PUBLIC" | "INTERFACE")
-        })
-        .map(|item| item.trim().to_string())
-        .collect()
-}
+    while i < chars.len() {
+        let c = chars[i];
+        if escaped {
+            current.push(c);
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if c == '\\' && (in_single || in_double) {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+        if c == '"' && !in_single {
+            in_double = !in_double;
+            i += 1;
+            continue;
+        }
+        if c == '\'' && !in_double {
+            in_single = !in_single;
+            i += 1;
+            continue;
+        }
+        if (in_single || in_double) && c == '#' {
+            current.push(c);
+            i += 1;
+            continue;
+        }
+        if !in_single && !in_double && c.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(current.clone());
+                current.clear();
+            }
+            i += 1;
+            continue;
+        }
+        if !in_single && !in_double && c == '#' {
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        current.push(c);
+        i += 1;
+    }
 
-fn split_link_libraries_args(s: &str) -> Vec<String> {
-    let cleaned = strip_cmake_line_comments(s);
-    cleaned
-        .split_whitespace()
-        .filter(|item| !item.is_empty())
-        .filter(|item| {
-            let upper = item.to_ascii_uppercase();
-            !matches!(
-                upper.as_str(),
-                "PUBLIC"
-                    | "PRIVATE"
-                    | "INTERFACE"
-                    | "DEBUG"
-                    | "OPTIMIZED"
-                    | "GENERAL"
-                    | "LINK_PUBLIC"
-                    | "LINK_PRIVATE"
-                    | "LINK_INTERFACE_LIBRARIES"
-            )
-        })
-        .map(|item| item.trim().to_string())
-        .collect()
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -63,10 +63,12 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
         info.target_link_libraries.push(TargetLinks { target, libraries });
     }
 
-    if uncommented_text.to_ascii_lowercase().contains("catkin_package") {
+    let re_catkin_package = Regex::new(r"(?i)\bcatkin_package\s*\(").unwrap();
+    if re_catkin_package.is_match(&uncommented_text) {
         info.has_catkin_package = true;
     }
-    if uncommented_text.to_ascii_lowercase().contains("ament_package") {
+    let re_ament_package = Regex::new(r"(?i)\bament_package\s*\(").unwrap();
+    if re_ament_package.is_match(&uncommented_text) {
         info.has_ament_package = true;
     }
 

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -1,261 +1,185 @@
 use crate::models::cmake::{CMakeInfo, FindPackage, TargetDependencies, TargetLinks};
 use anyhow::Result;
+use cmake_parser::{parse_cmakelists, Command, Doc, Token};
+use regex::Regex;
 use std::fs;
-
-#[derive(Debug, Clone)]
-struct CMakeCommand {
-    name: String,
-    args_raw: String,
-}
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
-    let commands = extract_cmake_commands(&text);
     let mut info = CMakeInfo::default();
 
-    for cmd in &commands {
-        match cmd.name.as_str() {
-            "find_package" => {
-                let tokens = tokenize_cmake_args(&cmd.args_raw);
-                if tokens.is_empty() {
-                    continue;
-                }
-                let name = tokens[0].clone();
-                let version = tokens
-                    .get(1)
-                    .filter(|t| t.chars().all(|c| c.is_ascii_digit() || c == '.'))
-                    .cloned();
-                let required = tokens.iter().any(|t| t.eq_ignore_ascii_case("REQUIRED"));
+    parse_standard_commands(&text, &mut info)?;
+    normalize_find_package_required_flags(&text, &mut info)?;
+    parse_ros_commands(&text, &mut info)?;
+
+    Ok(info)
+}
+
+fn parse_standard_commands(text: &str, info: &mut CMakeInfo) -> Result<()> {
+    let tokens = parse_cmakelists(text.as_bytes())?;
+    let doc = Doc::from(tokens);
+
+    for cmd in doc.to_commands_iter() {
+        let Ok(cmd) = cmd else {
+            continue;
+        };
+
+        match cmd {
+            Command::FindPackage(pkg) => {
+                let (name, version, required) = match pkg.as_ref() {
+                    cmake_parser::command::scripting::FindPackage::Basic(basic) => (
+                        token_to_string(&basic.package_name),
+                        basic.version.as_ref().map(token_to_string),
+                        required_from_basic_components(basic.components.as_ref()),
+                    ),
+                    cmake_parser::command::scripting::FindPackage::Full(full) => (
+                        token_to_string(&full.package_name),
+                        full.version.as_ref().map(token_to_string),
+                        required_from_full_components(full.components.as_ref()),
+                    ),
+                };
+
                 info.find_packages.push(FindPackage {
                     name,
                     version,
                     required,
                 });
             }
-            "add_executable" => {
-                let tokens = tokenize_cmake_args(&cmd.args_raw);
-                if let Some(target) = tokens.first() {
-                    info.executables.push(target.clone());
-                }
+            Command::AddExecutable(exec) => {
+                info.executables.push(token_to_string(&exec.name));
             }
-            "add_library" => {
-                let tokens = tokenize_cmake_args(&cmd.args_raw);
-                if let Some(target) = tokens.first() {
-                    info.libraries.push(target.clone());
-                }
-            }
-            "ament_target_dependencies" => {
-                let tokens = tokenize_cmake_args(&cmd.args_raw);
-                if let Some((target, rest)) = tokens.split_first() {
-                    let dependencies = rest
-                        .iter()
-                        .filter(|item| {
-                            !matches!(
-                                item.to_ascii_uppercase().as_str(),
-                                "SYSTEM" | "PUBLIC" | "INTERFACE"
-                            )
-                        })
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    info.ament_target_dependencies.push(TargetDependencies {
-                        target: target.clone(),
-                        dependencies,
-                    });
-                }
-            }
-            "target_link_libraries" => {
-                let tokens = tokenize_cmake_args(&cmd.args_raw);
-                if let Some((target, rest)) = tokens.split_first() {
-                    let libraries = rest
-                        .iter()
-                        .filter(|item| {
-                            !matches!(
-                                item.to_ascii_uppercase().as_str(),
-                                "PUBLIC"
-                                    | "PRIVATE"
-                                    | "INTERFACE"
-                                    | "DEBUG"
-                                    | "OPTIMIZED"
-                                    | "GENERAL"
-                                    | "LINK_PUBLIC"
-                                    | "LINK_PRIVATE"
-                                    | "LINK_INTERFACE_LIBRARIES"
-                            )
-                        })
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    info.target_link_libraries.push(TargetLinks {
-                        target: target.clone(),
-                        libraries,
-                    });
-                }
-            }
-            "catkin_package" => {
-                info.has_catkin_package = true;
-            }
-            "ament_package" => {
-                info.has_ament_package = true;
+            Command::AddLibrary(lib) => {
+                info.libraries.push(token_to_string(&lib.name));
             }
             _ => {}
         }
     }
 
-    Ok(info)
+    Ok(())
 }
 
-fn extract_cmake_commands(s: &str) -> Vec<CMakeCommand> {
-    let mut commands = Vec::new();
-    let chars: Vec<char> = s.chars().collect();
-    let mut i = 0usize;
+fn normalize_find_package_required_flags(text: &str, info: &mut CMakeInfo) -> Result<()> {
+    let re_find = Regex::new(r"(?is)(?m)(^|\n)\s*find_package\s*\((.*?)\)")?;
+    let mut required_by_index = Vec::new();
 
-    while i < chars.len() {
-        if chars[i] == '#' {
-            while i < chars.len() && chars[i] != '\n' {
-                i += 1;
-            }
+    for cap in re_find.captures_iter(text) {
+        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
+            continue;
+        };
+        let tokens = tokenize_unquoted_args(args);
+        if tokens.is_empty() {
             continue;
         }
-
-        if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
-            let start = i;
-            i += 1;
-            while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
-                i += 1;
-            }
-            let name: String = chars[start..i].iter().collect();
-
-            let mut j = i;
-            while j < chars.len() && chars[j].is_whitespace() {
-                j += 1;
-            }
-            if j >= chars.len() || chars[j] != '(' {
-                i = j;
-                continue;
-            }
-
-            j += 1;
-            let args_start = j;
-            let mut depth = 1i32;
-            let mut in_single = false;
-            let mut in_double = false;
-            let mut escaped = false;
-
-            while j < chars.len() {
-                let c = chars[j];
-                if escaped {
-                    escaped = false;
-                    j += 1;
-                    continue;
-                }
-                if c == '\\' && (in_single || in_double) {
-                    escaped = true;
-                    j += 1;
-                    continue;
-                }
-                if c == '"' && !in_single {
-                    in_double = !in_double;
-                    j += 1;
-                    continue;
-                }
-                if c == '\'' && !in_double {
-                    in_single = !in_single;
-                    j += 1;
-                    continue;
-                }
-                if in_single || in_double {
-                    j += 1;
-                    continue;
-                }
-                if c == '#' {
-                    while j < chars.len() && chars[j] != '\n' {
-                        j += 1;
-                    }
-                    continue;
-                }
-                if c == '(' {
-                    depth += 1;
-                } else if c == ')' {
-                    depth -= 1;
-                    if depth == 0 {
-                        let args_raw: String = chars[args_start..j].iter().collect();
-                        commands.push(CMakeCommand {
-                            name: name.to_ascii_lowercase(),
-                            args_raw,
-                        });
-                        j += 1;
-                        break;
-                    }
-                }
-                j += 1;
-            }
-            i = j;
-            continue;
-        }
-
-        i += 1;
+        required_by_index.push(tokens.iter().skip(1).any(|t| t.eq_ignore_ascii_case("REQUIRED")));
     }
 
-    commands
+    for (pkg, required) in info.find_packages.iter_mut().zip(required_by_index.into_iter()) {
+        pkg.required = required;
+    }
+
+    Ok(())
 }
 
-fn tokenize_cmake_args(s: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    let chars: Vec<char> = s.chars().collect();
-    let mut i = 0usize;
-    let mut in_single = false;
-    let mut in_double = false;
-    let mut escaped = false;
-
-    while i < chars.len() {
-        let c = chars[i];
-        if escaped {
-            current.push(c);
-            escaped = false;
-            i += 1;
+fn parse_ros_commands(text: &str, info: &mut CMakeInfo) -> Result<()> {
+    let re_pkg = Regex::new(r"(?is)(?m)(^|\n)\s*(catkin_package|ament_package)\s*\((.*?)\)")?;
+    for cap in re_pkg.captures_iter(text) {
+        let Some(name) = cap.get(2).map(|m| m.as_str().to_ascii_lowercase()) else {
             continue;
+        };
+        match name.as_str() {
+            "catkin_package" => info.has_catkin_package = true,
+            "ament_package" => info.has_ament_package = true,
+            _ => {}
         }
-        if c == '\\' && (in_single || in_double) {
-            escaped = true;
-            i += 1;
-            continue;
-        }
-        if c == '"' && !in_single {
-            in_double = !in_double;
-            i += 1;
-            continue;
-        }
-        if c == '\'' && !in_double {
-            in_single = !in_single;
-            i += 1;
-            continue;
-        }
-        if (in_single || in_double) && c == '#' {
-            current.push(c);
-            i += 1;
-            continue;
-        }
-        if !in_single && !in_double && c.is_whitespace() {
-            if !current.is_empty() {
-                tokens.push(current.clone());
-                current.clear();
-            }
-            i += 1;
-            continue;
-        }
-        if !in_single && !in_double && c == '#' {
-            while i < chars.len() && chars[i] != '\n' {
-                i += 1;
-            }
-            continue;
-        }
-        current.push(c);
-        i += 1;
     }
 
-    if !current.is_empty() {
-        tokens.push(current);
+    let re_ament = Regex::new(r"(?is)(?m)(^|\n)\s*ament_target_dependencies\s*\((.*?)\)")?;
+    for cap in re_ament.captures_iter(text) {
+        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
+            continue;
+        };
+        let tokens = tokenize_unquoted_args(args);
+        if let Some((target, rest)) = tokens.split_first() {
+            let dependencies = rest
+                .iter()
+                .filter(|item| !is_ament_dependency_keyword(item))
+                .cloned()
+                .collect::<Vec<_>>();
+            info.ament_target_dependencies.push(TargetDependencies {
+                target: target.clone(),
+                dependencies,
+            });
+        }
     }
 
-    tokens
+    let re_link = Regex::new(r"(?is)(?m)(^|\n)\s*target_link_libraries\s*\((.*?)\)")?;
+    for cap in re_link.captures_iter(text) {
+        let Some(args) = cap.get(2).map(|m| m.as_str()) else {
+            continue;
+        };
+        let tokens = tokenize_unquoted_args(args);
+        if let Some((target, rest)) = tokens.split_first() {
+            let libraries = rest
+                .iter()
+                .filter(|item| !is_target_link_keyword(item))
+                .cloned()
+                .collect::<Vec<_>>();
+            info.target_link_libraries.push(TargetLinks {
+                target: target.clone(),
+                libraries,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn required_from_basic_components(
+    components: Option<&cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
+) -> bool {
+    use cmake_parser::command::scripting::find_package::PackageComponents;
+    matches!(components, Some(PackageComponents::Required(_)))
+}
+
+fn required_from_full_components(
+    components: Option<&cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
+) -> bool {
+    use cmake_parser::command::scripting::find_package::PackageComponents;
+    matches!(components, Some(PackageComponents::Required(_)))
+}
+
+fn token_to_string(token: &Token<'_>) -> String {
+    token.to_string()
+}
+
+fn tokenize_unquoted_args(s: &str) -> Vec<String> {
+    let mut stripped = String::new();
+    for line in s.lines() {
+        let before_comment = line.split('#').next().unwrap_or_default();
+        stripped.push_str(before_comment);
+        stripped.push('\n');
+    }
+    stripped
+        .split_whitespace()
+        .map(|x| x.to_string())
+        .collect()
+}
+
+fn is_ament_dependency_keyword(s: &str) -> bool {
+    matches!(s.to_ascii_uppercase().as_str(), "SYSTEM" | "PUBLIC" | "INTERFACE")
+}
+
+fn is_target_link_keyword(s: &str) -> bool {
+    matches!(
+        s.to_ascii_uppercase().as_str(),
+        "PUBLIC"
+            | "PRIVATE"
+            | "INTERFACE"
+            | "DEBUG"
+            | "OPTIMIZED"
+            | "GENERAL"
+            | "LINK_PUBLIC"
+            | "LINK_PRIVATE"
+            | "LINK_INTERFACE_LIBRARIES"
+    )
 }

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -15,33 +15,36 @@ pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let tokens = parse_cmakelists(parse_text.as_bytes())?;
     let doc = Doc::from(tokens);
 
-    parse_standard_commands(&doc, &mut info)?;
-    normalize_find_package_required_flags(&doc, &mut info);
+    parse_standard_and_find_package_commands(&doc, &mut info)?;
     parse_ros_and_raw_commands(&doc, &mut info);
 
     Ok(info)
 }
 
-fn parse_standard_commands(doc: &Doc<'_>, info: &mut CMakeInfo) -> Result<()> {
-    for cmd in doc.to_commands_iter() {
+fn parse_standard_and_find_package_commands(doc: &Doc<'_>, info: &mut CMakeInfo) -> Result<()> {
+    for (raw, cmd) in doc.raw_commands().zip(doc.to_commands_iter()) {
         let Ok(cmd) = cmd else {
             continue;
         };
 
         match cmd {
             Command::FindPackage(pkg) => {
-                let (name, version, required) = match pkg.as_ref() {
+                let (name, version) = match pkg.as_ref() {
                     ros_cmake_parser::command::scripting::FindPackage::Basic(basic) => (
                         token_to_string(&basic.package_name),
                         basic.version.as_ref().map(token_to_string),
-                        required_from_basic_components(basic.components.as_ref()),
                     ),
                     ros_cmake_parser::command::scripting::FindPackage::Full(full) => (
                         token_to_string(&full.package_name),
                         full.version.as_ref().map(token_to_string),
-                        required_from_full_components(full.components.as_ref()),
                     ),
                 };
+
+                let required = raw
+                    .tokens
+                    .iter()
+                    .skip(1)
+                    .any(|t| eq_ignore_ascii_case(t.as_ref(), b"REQUIRED"));
 
                 info.find_packages.push(FindPackage {
                     name,
@@ -60,23 +63,6 @@ fn parse_standard_commands(doc: &Doc<'_>, info: &mut CMakeInfo) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn normalize_find_package_required_flags(doc: &Doc<'_>, info: &mut CMakeInfo) {
-    let required_by_index = doc
-        .raw_commands()
-        .filter(|raw| eq_ignore_ascii_case(raw.identifier.as_ref(), b"find_package"))
-        .filter(|raw| !raw.tokens.is_empty())
-        .map(|raw| {
-            raw.tokens
-                .iter()
-                .skip(1)
-                .any(|t| eq_ignore_ascii_case(t.as_ref(), b"REQUIRED"))
-        });
-
-    for (pkg, required) in info.find_packages.iter_mut().zip(required_by_index) {
-        pkg.required = required;
-    }
 }
 
 fn parse_ros_and_raw_commands(doc: &Doc<'_>, info: &mut CMakeInfo) {
@@ -108,20 +94,6 @@ fn parse_ros_and_raw_commands(doc: &Doc<'_>, info: &mut CMakeInfo) {
             }
         }
     }
-}
-
-fn required_from_basic_components(
-    components: Option<&ros_cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
-) -> bool {
-    use ros_cmake_parser::command::scripting::find_package::PackageComponents;
-    matches!(components, Some(PackageComponents::Required(_)))
-}
-
-fn required_from_full_components(
-    components: Option<&ros_cmake_parser::command::scripting::find_package::PackageComponents<'_>>,
-) -> bool {
-    use ros_cmake_parser::command::scripting::find_package::PackageComponents;
-    matches!(components, Some(PackageComponents::Required(_)))
 }
 
 fn token_to_string(token: &Token<'_>) -> String {

--- a/src/parsers/cmake.rs
+++ b/src/parsers/cmake.rs
@@ -6,11 +6,12 @@ use std::fs;
 
 pub fn parse_cmake_lists(path: &str) -> Result<CMakeInfo> {
     let text = fs::read_to_string(path)?;
+    let aux_text = strip_cmake_bracket_comments(&text);
     let mut info = CMakeInfo::default();
 
     parse_standard_commands(&text, &mut info)?;
-    normalize_find_package_required_flags(&text, &mut info)?;
-    parse_ros_commands(&text, &mut info)?;
+    normalize_find_package_required_flags(&aux_text, &mut info)?;
+    parse_ros_commands(&aux_text, &mut info)?;
 
     Ok(info)
 }
@@ -163,6 +164,59 @@ fn tokenize_unquoted_args(s: &str) -> Vec<String> {
         .split_whitespace()
         .map(|x| x.to_string())
         .collect()
+}
+
+fn strip_cmake_bracket_comments(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        if bytes[i] == b'#' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            let mut eqs = 0usize;
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] == b'=' {
+                eqs += 1;
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'[' {
+                let start = j + 1;
+                let mut k = start;
+                let mut found = false;
+                while k < bytes.len() {
+                    if bytes[k] == b']' {
+                        let mut m = k + 1;
+                        let mut matched_eqs = 0usize;
+                        while matched_eqs < eqs && m < bytes.len() && bytes[m] == b'=' {
+                            matched_eqs += 1;
+                            m += 1;
+                        }
+                        if matched_eqs == eqs && m < bytes.len() && bytes[m] == b']' {
+                            for &b in &bytes[i..=m] {
+                                if b == b'\n' {
+                                    out.push('\n');
+                                } else {
+                                    out.push(' ');
+                                }
+                            }
+                            i = m + 1;
+                            found = true;
+                            break;
+                        }
+                    }
+                    k += 1;
+                }
+                if found {
+                    continue;
+                }
+            }
+        }
+
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    out
 }
 
 fn is_ament_dependency_keyword(s: &str) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -250,6 +250,54 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
     }
 
     #[test]
+    fn parse_cmake_lists_supports_uppercase_commands() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"ADD_EXECUTABLE(MY_NODE src/my_node.cpp)
+ADD_LIBRARY(MY_LIB SHARED src/my_lib.cpp)
+AMENT_TARGET_DEPENDENCIES(MY_NODE rclcpp std_msgs)
+TARGET_LINK_LIBRARIES(MY_NODE PUBLIC MY_LIB foo::bar)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.executables.iter().any(|t| t == "MY_NODE"));
+        assert!(info.libraries.iter().any(|t| t == "MY_LIB"));
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "MY_NODE" && entry.dependencies == vec!["rclcpp", "std_msgs"]
+        }));
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "MY_NODE" && entry.libraries == vec!["MY_LIB", "foo::bar"]
+        }));
+    }
+
+    #[test]
+    fn parse_cmake_lists_strips_line_comments_from_args() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"ament_target_dependencies(my_node rclcpp # core ros client
+  std_msgs)
+target_link_libraries(my_node my_lib # internal lib
+  foo::bar)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "my_node" && entry.dependencies == vec!["rclcpp", "std_msgs"]
+        }));
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "my_node" && entry.libraries == vec!["my_lib", "foo::bar"]
+        }));
+    }
+
+    #[test]
     fn analyze_command_writes_json_report() {
         let td = tempdir().expect("tempdir");
         let base = td.path();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -210,7 +210,9 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
         assert!(info.target_link_libraries.iter().any(|entry| {
             entry.target == "my_node"
                 && entry.libraries
-                    == vec!["my_lib", "foo::bar", "baz::qux", "optlib", "dbgllib", "genlib"]
+                    == vec![
+                        "my_lib", "foo::bar", "baz::qux", "optlib", "dbgllib", "genlib",
+                    ]
         }));
     }
 
@@ -244,8 +246,7 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
         let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
 
         assert!(info.target_link_libraries.iter().any(|entry| {
-            entry.target == "my_node"
-                && entry.libraries == vec!["my_lib", "foo::bar", "baz::qux"]
+            entry.target == "my_node" && entry.libraries == vec!["my_lib", "foo::bar", "baz::qux"]
         }));
     }
 
@@ -267,9 +268,18 @@ TARGET_LINK_LIBRARIES(MY_NODE public MY_LIB foo::bar)"#,
 
         let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
 
-        assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
-        assert!(info.find_packages.iter().any(|pkg| pkg.name == "std_msgs" && pkg.required));
-        assert!(info.find_packages.iter().any(|pkg| pkg.name == "foo" && !pkg.required));
+        assert!(info
+            .find_packages
+            .iter()
+            .any(|pkg| pkg.name == "rclcpp" && pkg.required));
+        assert!(info
+            .find_packages
+            .iter()
+            .any(|pkg| pkg.name == "std_msgs" && pkg.required));
+        assert!(info
+            .find_packages
+            .iter()
+            .any(|pkg| pkg.name == "foo" && !pkg.required));
         assert_eq!(info.find_packages.len(), 3);
         assert!(info.executables.iter().any(|t| t == "MY_NODE"));
         assert!(info.libraries.iter().any(|t| t == "MY_LIB"));
@@ -326,10 +336,14 @@ target_link_libraries(real_node real_lib)
         assert!(info.libraries.is_empty());
         assert!(!info.has_catkin_package);
         assert!(!info.has_ament_package);
-        assert!(info.target_link_libraries.iter().any(|entry| {
-            entry.target == "real_node" && entry.libraries == vec!["real_lib"]
-        }));
-        assert!(!info.target_link_libraries.iter().any(|entry| entry.target == "old_node"));
+        assert!(info
+            .target_link_libraries
+            .iter()
+            .any(|entry| { entry.target == "real_node" && entry.libraries == vec!["real_lib"] }));
+        assert!(!info
+            .target_link_libraries
+            .iter()
+            .any(|entry| entry.target == "old_node"));
     }
 
     #[test]
@@ -370,19 +384,24 @@ target_link_libraries(real_node real_lib)"#,
 
         let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
 
-        assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
+        assert!(info
+            .find_packages
+            .iter()
+            .any(|pkg| pkg.name == "rclcpp" && pkg.required));
         assert!(!info.find_packages.iter().any(|pkg| pkg.name == "fake_pkg"));
         assert!(!info.has_ament_package);
-        assert!(info.ament_target_dependencies.iter().any(|entry| {
-            entry.target == "real_node" && entry.dependencies == vec!["rclcpp"]
-        }));
+        assert!(info
+            .ament_target_dependencies
+            .iter()
+            .any(|entry| { entry.target == "real_node" && entry.dependencies == vec!["rclcpp"] }));
         assert!(!info
             .ament_target_dependencies
             .iter()
             .any(|entry| entry.target == "fake_node"));
-        assert!(info.target_link_libraries.iter().any(|entry| {
-            entry.target == "real_node" && entry.libraries == vec!["real_lib"]
-        }));
+        assert!(info
+            .target_link_libraries
+            .iter()
+            .any(|entry| { entry.target == "real_node" && entry.libraries == vec!["real_lib"] }));
         assert!(!info
             .target_link_libraries
             .iter()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -167,6 +167,54 @@ ament_package()
     }
 
     #[test]
+    fn parse_cmake_lists_supports_variable_target_names() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"cmake_minimum_required(VERSION 3.8)
+project(sample_pkg)
+
+add_executable(${PROJECT_NAME}_node src/my_node.cpp)
+ament_target_dependencies(${PROJECT_NAME}_node rclcpp std_msgs)
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
+"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.executables.iter().any(|t| t == "${PROJECT_NAME}_node"));
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "${PROJECT_NAME}_node"
+                && entry.dependencies == vec!["rclcpp", "std_msgs"]
+        }));
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "${PROJECT_NAME}_node"
+                && entry.libraries == vec!["${PROJECT_NAME}_core", "foo::bar"]
+        }));
+    }
+
+    #[test]
+    fn parse_cmake_lists_ignores_link_visibility_keywords() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"target_link_libraries(my_node PUBLIC my_lib PRIVATE foo::bar INTERFACE baz::qux optimized optlib debug dbgllib general genlib)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "my_node"
+                && entry.libraries
+                    == vec!["my_lib", "foo::bar", "baz::qux", "optlib", "dbgllib", "genlib"]
+        }));
+    }
+
+    #[test]
     fn analyze_command_writes_json_report() {
         let td = tempdir().expect("tempdir");
         let base = td.path();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -312,7 +312,9 @@ target_link_libraries(my_node my_lib # internal lib
 # ADD_LIBRARY(OLD_LIB SHARED src/old.cpp)
 add_executable(real_node src/real.cpp)
 # target_link_libraries(old_node old_lib)
-target_link_libraries(real_node real_lib)"#,
+target_link_libraries(real_node real_lib)
+# catkin_package()
+# ament_package()"#,
         )
         .expect("write CMakeLists.txt");
 
@@ -320,10 +322,29 @@ target_link_libraries(real_node real_lib)"#,
 
         assert_eq!(info.executables, vec!["real_node"]);
         assert!(info.libraries.is_empty());
+        assert!(!info.has_catkin_package);
+        assert!(!info.has_ament_package);
         assert!(info.target_link_libraries.iter().any(|entry| {
             entry.target == "real_node" && entry.libraries == vec!["real_lib"]
         }));
         assert!(!info.target_link_libraries.iter().any(|entry| entry.target == "old_node"));
+    }
+
+    #[test]
+    fn parse_cmake_lists_detects_package_commands_case_insensitively() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"CATKIN_PACKAGE()
+AMENT_PACKAGE()"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.has_catkin_package);
+        assert!(info.has_ament_package);
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -350,6 +350,25 @@ AMENT_PACKAGE()"#,
     }
 
     #[test]
+    fn parse_cmake_lists_does_not_match_wrapper_macro_names() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"foo_add_executable(fake_node src/fake.cpp)
+my_target_link_libraries(fake_node fake_lib)
+real_add_library(fake_lib src/fake.cpp)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.executables.is_empty());
+        assert!(info.libraries.is_empty());
+        assert!(info.target_link_libraries.is_empty());
+    }
+
+    #[test]
     fn analyze_command_writes_json_report() {
         let td = tempdir().expect("tempdir");
         let base = td.path();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -256,6 +256,7 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
         write(
             &cmake_path,
             r#"FIND_PACKAGE(rclcpp required)
+FIND_PACKAGE(std_msgs REQUIRED)
 ADD_EXECUTABLE(MY_NODE src/my_node.cpp)
 ADD_LIBRARY(MY_LIB SHARED src/my_lib.cpp)
 AMENT_TARGET_DEPENDENCIES(MY_NODE rclcpp std_msgs)
@@ -266,6 +267,8 @@ TARGET_LINK_LIBRARIES(MY_NODE public MY_LIB foo::bar)"#,
         let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
 
         assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
+        assert!(info.find_packages.iter().any(|pkg| pkg.name == "std_msgs" && pkg.required));
+        assert_eq!(info.find_packages.len(), 2);
         assert!(info.executables.iter().any(|t| t == "MY_NODE"));
         assert!(info.libraries.iter().any(|t| t == "MY_LIB"));
         assert!(info.ament_target_dependencies.iter().any(|entry| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -350,6 +350,46 @@ AMENT_PACKAGE()"#,
     }
 
     #[test]
+    fn parse_cmake_lists_ignores_bracket_commented_ros_commands() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"find_package(rclcpp REQUIRED)
+#[[
+find_package(fake_pkg REQUIRED)
+ament_target_dependencies(fake_node fake_dep)
+target_link_libraries(fake_node fake_lib)
+ament_package()
+]]
+add_executable(real_node src/real.cpp)
+ament_target_dependencies(real_node rclcpp)
+target_link_libraries(real_node real_lib)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
+        assert!(!info.find_packages.iter().any(|pkg| pkg.name == "fake_pkg"));
+        assert!(!info.has_ament_package);
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "real_node" && entry.dependencies == vec!["rclcpp"]
+        }));
+        assert!(!info
+            .ament_target_dependencies
+            .iter()
+            .any(|entry| entry.target == "fake_node"));
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "real_node" && entry.libraries == vec!["real_lib"]
+        }));
+        assert!(!info
+            .target_link_libraries
+            .iter()
+            .any(|entry| entry.target == "fake_node"));
+    }
+
+    #[test]
     fn parse_cmake_lists_does_not_match_wrapper_macro_names() {
         let td = tempdir().expect("tempdir");
         let cmake_path = td.path().join("CMakeLists.txt");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,6 +7,7 @@ mod cli_tests {
     use crate::analyzer::analyze;
     use crate::commands;
     use crate::models::AnalysisReport;
+    use crate::parsers::cmake::parse_cmake_lists;
     use crate::parsers::package::parse_package_xml;
     use crate::plugins::loader::load_rules_from_path;
     use crate::scanner::scan_workspace;
@@ -130,6 +131,39 @@ suggestion = "#include <rclcpp/rclcpp.hpp>"
 
         let pkg = parse_package_xml(pkg_path.to_str().unwrap()).expect("parse package.xml");
         assert_eq!(pkg.build_type.as_deref(), Some("ament_cmake"));
+    }
+
+    #[test]
+    fn parse_cmake_lists_extracts_targets_and_dependencies() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"cmake_minimum_required(VERSION 3.8)
+project(sample_pkg)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_executable(my_node src/my_node.cpp)
+add_library(my_lib SHARED src/my_lib.cpp)
+ament_target_dependencies(my_node rclcpp std_msgs)
+target_link_libraries(my_node my_lib foo::bar)
+ament_package()
+"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.executables.iter().any(|t| t == "my_node"));
+        assert!(info.libraries.iter().any(|t| t == "my_lib"));
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "my_node" && entry.dependencies == vec!["rclcpp", "std_msgs"]
+        }));
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "my_node" && entry.libraries == vec!["my_lib", "foo::bar"]
+        }));
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -255,15 +255,17 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
         let cmake_path = td.path().join("CMakeLists.txt");
         write(
             &cmake_path,
-            r#"ADD_EXECUTABLE(MY_NODE src/my_node.cpp)
+            r#"FIND_PACKAGE(rclcpp required)
+ADD_EXECUTABLE(MY_NODE src/my_node.cpp)
 ADD_LIBRARY(MY_LIB SHARED src/my_lib.cpp)
 AMENT_TARGET_DEPENDENCIES(MY_NODE rclcpp std_msgs)
-TARGET_LINK_LIBRARIES(MY_NODE PUBLIC MY_LIB foo::bar)"#,
+TARGET_LINK_LIBRARIES(MY_NODE public MY_LIB foo::bar)"#,
         )
         .expect("write CMakeLists.txt");
 
         let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
 
+        assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
         assert!(info.executables.iter().any(|t| t == "MY_NODE"));
         assert!(info.libraries.iter().any(|t| t == "MY_LIB"));
         assert!(info.ament_target_dependencies.iter().any(|entry| {
@@ -295,6 +297,30 @@ target_link_libraries(my_node my_lib # internal lib
         assert!(info.target_link_libraries.iter().any(|entry| {
             entry.target == "my_node" && entry.libraries == vec!["my_lib", "foo::bar"]
         }));
+    }
+
+    #[test]
+    fn parse_cmake_lists_ignores_commented_out_commands() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"# add_executable(old_node src/old.cpp)
+# ADD_LIBRARY(OLD_LIB SHARED src/old.cpp)
+add_executable(real_node src/real.cpp)
+# target_link_libraries(old_node old_lib)
+target_link_libraries(real_node real_lib)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert_eq!(info.executables, vec!["real_node"]);
+        assert!(info.libraries.is_empty());
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "real_node" && entry.libraries == vec!["real_lib"]
+        }));
+        assert!(!info.target_link_libraries.iter().any(|entry| entry.target == "old_node"));
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -257,6 +257,7 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
             &cmake_path,
             r#"FIND_PACKAGE(rclcpp required)
 FIND_PACKAGE(std_msgs REQUIRED)
+FIND_PACKAGE(foo COMPONENTS required_tools)
 ADD_EXECUTABLE(MY_NODE src/my_node.cpp)
 ADD_LIBRARY(MY_LIB SHARED src/my_lib.cpp)
 AMENT_TARGET_DEPENDENCIES(MY_NODE rclcpp std_msgs)
@@ -268,7 +269,8 @@ TARGET_LINK_LIBRARIES(MY_NODE public MY_LIB foo::bar)"#,
 
         assert!(info.find_packages.iter().any(|pkg| pkg.name == "rclcpp" && pkg.required));
         assert!(info.find_packages.iter().any(|pkg| pkg.name == "std_msgs" && pkg.required));
-        assert_eq!(info.find_packages.len(), 2);
+        assert!(info.find_packages.iter().any(|pkg| pkg.name == "foo" && !pkg.required));
+        assert_eq!(info.find_packages.len(), 3);
         assert!(info.executables.iter().any(|t| t == "MY_NODE"));
         assert!(info.libraries.iter().any(|t| t == "MY_LIB"));
         assert!(info.ament_target_dependencies.iter().any(|entry| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -215,6 +215,41 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_core foo::bar)
     }
 
     #[test]
+    fn parse_cmake_lists_ignores_ament_dependency_keywords() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"ament_target_dependencies(my_node SYSTEM PUBLIC INTERFACE rclcpp std_msgs)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.ament_target_dependencies.iter().any(|entry| {
+            entry.target == "my_node" && entry.dependencies == vec!["rclcpp", "std_msgs"]
+        }));
+    }
+
+    #[test]
+    fn parse_cmake_lists_ignores_legacy_link_keywords() {
+        let td = tempdir().expect("tempdir");
+        let cmake_path = td.path().join("CMakeLists.txt");
+        write(
+            &cmake_path,
+            r#"target_link_libraries(my_node LINK_PUBLIC my_lib LINK_PRIVATE foo::bar LINK_INTERFACE_LIBRARIES baz::qux)"#,
+        )
+        .expect("write CMakeLists.txt");
+
+        let info = parse_cmake_lists(cmake_path.to_str().unwrap()).expect("parse cmake");
+
+        assert!(info.target_link_libraries.iter().any(|entry| {
+            entry.target == "my_node"
+                && entry.libraries == vec!["my_lib", "foo::bar", "baz::qux"]
+        }));
+    }
+
+    #[test]
     fn analyze_command_writes_json_report() {
         let td = tempdir().expect("tempdir");
         let base = td.path();


### PR DESCRIPTION

Initial implementation for richer CMake analysis.

Includes:
- target extraction from add_executable / add_library\n
- dependency extraction from ament_target_dependencies\n
- link extraction from target_link_libraries\n
- tests for expected parsing behavior